### PR TITLE
Add optional matplotlib color parsing (#12)

### DIFF
--- a/stacmap/utils.py
+++ b/stacmap/utils.py
@@ -3,7 +3,21 @@ import numpy as np
 
 
 def get_cmap(cmap: str, n: int):
-    """Take a colormap name (or possibly a list of colors or a colormap object?) and return ???. Maybe an n-sized list of hex colors? Need to think about it."""
+    """Take a colormap name and return an n-length list of colors. matplotlib will
+    be used to parse color names if available. Otherwise, branca will be used.
+
+    Parameters
+    ----------
+    cmap : str
+        The name of the colormap to retrieve.
+    n : int
+        The number of colors to retrieve.
+
+    Returns
+    -------
+    list
+        A list of hex colors.
+    """
     try:
         import matplotlib
     except ImportError:

--- a/stacmap/utils.py
+++ b/stacmap/utils.py
@@ -1,0 +1,21 @@
+import branca
+import numpy as np
+
+
+def get_cmap(cmap: str, n: int):
+    """Take a colormap name (or possibly a list of colors or a colormap object?) and return ???. Maybe an n-sized list of hex colors? Need to think about it."""
+    try:
+        import matplotlib
+    except ImportError:
+        matplotlib = None
+
+    if matplotlib is not None:
+        colors = matplotlib.cm.get_cmap(cmap)(np.linspace(0, 1, n))
+        return np.apply_along_axis(matplotlib.colors.to_hex, 1, colors)
+    try:
+        base_colors = branca.utilities.color_brewer(cmap)
+        return branca.utilities.linear_gradient(base_colors, n)
+    except ValueError:
+        raise ValueError(
+            f"Unrecognized cmap: `{cmap}`. Installing matplotlib with `pip install matplotlib` may resolve this error."
+        ) from None

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,33 @@
+import sys
+
+import pytest
+
+from stacmap import utils
+
+
+def test_cmap_branca():
+    """Test that branca successfully retrieves a colorbrewer colormap"""
+    # Force matplotlib import to fail
+    sys.modules["matplotlib"] = None
+
+    colors = utils.get_cmap("RdBu", 79)
+    assert len(colors) == 79
+
+    del sys.modules["matplotlib"]
+
+
+def test_cmap_matplotlib():
+    """Test that matplotlib succesfully retrieves a non-colorbrewer colormap"""
+    colors = utils.get_cmap("viridis", 31)
+    assert len(colors) == 31
+
+
+def test_cmap_matplotlib_missing():
+    """Test that an error is raised if a non-colorbrewer colormap is requested without matplotlib"""
+    # Force matplotlib import to fail
+    sys.modules["matplotlib"] = None
+
+    with pytest.raises(ValueError):
+        utils.get_cmap("viridis", 8)
+
+    del sys.modules["matplotlib"]


### PR DESCRIPTION
Close #12 by adding support for parsing `matplotlib` colormaps if the package is available. If not and `branca` is unable to parse the colormap, `pip install matplotlib` will be recommended.