### PR TITLE
Add test coverage and close #6

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,8 @@
 dist/
 *.egg-info/
 docs/build/
+htmlcov/
+__pycache__/
+.pytest_cache/
+.mypy_cache/
+.coverage

--- a/Makefile
+++ b/Makefile
@@ -52,3 +52,10 @@ release: ## Package and upload
 
 tests: ## Run unit tests
 	pytest .
+
+coverage: ## Run unit tests and produce a coverage HTML
+	coverage run --omit="tests/*" -m pytest . 
+	coverage html
+
+view-coverage: ## Open coverage HTML in a browser
+	python -m webbrowser -t htmlcov/index.html

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ with open("README.md", encoding="utf-8") as readme_file:
 
 requirements = ["pystac", "folium", "numpy", "branca"]
 doc_requirements = ["nbsphinx", "sphinx", "sphinx_rtd_theme"]
-test_requirements = ["pytest"]
+test_requirements = ["pytest", "coverage"]
 dev_requirements = (
     [
         "pre-commit",

--- a/tests/data/planet-example-v1.0.0-beta.2/collection.json
+++ b/tests/data/planet-example-v1.0.0-beta.2/collection.json
@@ -1,0 +1,105 @@
+{
+    "id": "planet-disaster-data",
+    "stac_version": "1.0.0-beta.2",
+    "stac_extensions": [
+        "https://stac-extensions.github.io/eo/v1.0.0/schema.json",
+        "https://stac-extensions.github.io/view/v1.0.0/schema.json"
+    ],
+    "description": "[Planet Disaster Data](https://www.planet.com/disasterdata/) makes imagery available directly to the public, volunteers, humanitarian organizations, and other coordinating bodies in support of the International Charter for Space and Major Disasters. Data is released for individual disaster events, providing a 30 day window pre- and post-disaster. Imagery is provided under Creative Commons licenses, free of charge, with either CC-BY-SA or CC-BY-NC.",
+    "links": [
+        {
+            "rel": "root",
+            "href": "./collection.json",
+            "type": "application/json"
+        },
+        {
+            "rel": "child",
+            "href": "./hurricane-harvey/catalog.json",
+            "title": "Hurricane Harvey"
+        }
+    ],
+    "title": "Planet Disaster Data",
+    "keywords": [
+        "disaster",
+        "open"
+    ],
+    "providers": [
+        {
+            "name": "Planet",
+            "description": "Contact Planet at [planet.com/contact-sales](https://www.planet.com/contact-sales/)",
+            "roles": [
+                "producer",
+                "processor"
+            ],
+            "url": "http://planet.com"
+        },
+        {
+            "name": "Planet Disaster Team",
+            "description": "The Planet Disaster Data Team (<disaster-team@planet.com>) has released this data as CC-BY-SA-4.0 to help disaster response",
+            "roles": [
+                "licensor"
+            ],
+            "url": "https://www.planet.com/disasterdata/"
+        },
+        {
+            "name": "GitHub",
+            "description": "This catalog is hosted in the [sample-stac](https://github.com/cholmes/sample-stac) repository on GitHub",
+            "roles": [
+                "host"
+            ],
+            "url": "https://github.com"
+        }
+    ],
+    "summaries": {
+        "constellation": [
+            "skysat",
+            "planetscope"
+        ],
+        "platform": [
+            "SS02",
+            "SSC1",
+            "101c"
+        ],
+        "view:off_nadir": {
+            "min": 0.2,
+            "max": 27.3
+        },
+        "view:sun_elevation": {
+            "min": 56.3,
+            "max": 65.1
+        },
+        "view:sun_azimuth": {
+            "min": 122,
+            "max": 231.9
+        },
+        "eo:gsd": {
+            "min": 0.9,
+            "max": 3.7
+        },
+        "eo:cloud_cover": {
+            "min": 0,
+            "max": 24
+        }
+    },
+    "extent": {
+        "spatial": {
+            "bbox": [
+                [
+                    -96,
+                    28,
+                    -93,
+                    31
+                ]
+            ]
+        },
+        "temporal": {
+            "interval": [
+                [
+                    "2017-08-28T10:00:00+00:00",
+                    null
+                ]
+            ]
+        }
+    },
+    "license": "CC-BY-SA-4.0"
+}

--- a/tests/data/planet-example-v1.0.0-beta.2/hurricane-harvey/catalog.json
+++ b/tests/data/planet-example-v1.0.0-beta.2/hurricane-harvey/catalog.json
@@ -1,0 +1,23 @@
+{
+    "id": "hurricane-harvey",
+    "stac_version": "1.0.0-beta.2",
+    "description": "Planet Disaster Data makes imagery available directly to the public, volunteers, humanitarian organizations, and other coordinating bodies in support of the International Charter for Space and Major Disasters. This catalog of data is released for Hurricane Harvey, providing a 30 day window pre- and post-disaster. Imagery is provided under Creative Commons licenses, free of charge, with either CC-BY-SA or CC-BY-NC. All new Planet scenes are made available each day, immediately after production. ",
+    "links": [
+        {
+            "rel": "root",
+            "href": "../collection.json",
+            "type": "application/json"
+        },
+        {
+            "rel": "parent",
+            "href": "../collection.json",
+            "type": "application/json"
+        },
+        {
+            "rel": "child",
+            "href": "./hurricane-harvey-0831/catalog.json",
+            "title": "8/31"
+        }
+    ],
+    "title": "Hurricane Harvey"
+}

--- a/tests/data/planet-example-v1.0.0-beta.2/hurricane-harvey/hurricane-harvey-0831/20170831_162740_ssc1d1/20170831_162740_ssc1d1.json
+++ b/tests/data/planet-example-v1.0.0-beta.2/hurricane-harvey/hurricane-harvey-0831/20170831_162740_ssc1d1/20170831_162740_ssc1d1.json
@@ -1,0 +1,163 @@
+{
+    "type": "Feature",
+    "stac_version": "1.0.0-rc.3",
+    "id": "20170831_162740_ssc1d1",
+    "properties": {
+        "datetime": "2017-08-31T16:27:42.176605Z",
+        "platform": "SSC1",
+        "constellation": "skysat",
+        "updated": "2017-11-01T21:09:02Z",
+        "created": "2017-09-01T19:37:35Z",
+        "gsd": 0.9,
+        "eo:cloud_cover": 0,
+        "view:azimuth": 121.3,
+        "view:sun_azimuth": 122,
+        "view:sun_elevation": 56.3,
+        "view:off_nadir": 27.2,
+        "pl:ground_control": true,
+        "pl:item_type": "SkySatScene",
+        "pl:quality_category": "standard",
+        "pl:strip_id": "s03_20170831T162740Z"
+    },
+    "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+            [
+                [
+                    -95.46998977661133,
+                    29.059245820517656
+                ],
+                [
+                    -95.46990394592285,
+                    29.049491960581708
+                ],
+                [
+                    -95.44741630554199,
+                    29.03215782622282
+                ],
+                [
+                    -95.46647071838379,
+                    29.01797318720572
+                ],
+                [
+                    -95.46561241149902,
+                    29.016997452585333
+                ],
+                [
+                    -95.46509742736816,
+                    29.017072509421837
+                ],
+                [
+                    -95.44072151184082,
+                    28.997931250084207
+                ],
+                [
+                    -95.28116226196289,
+                    28.872261720487128
+                ],
+                [
+                    -95.26768684387207,
+                    28.87241204397036
+                ],
+                [
+                    -95.25609970092773,
+                    28.884888134910938
+                ],
+                [
+                    -95.28794288635254,
+                    28.910737431999245
+                ],
+                [
+                    -95.27498245239258,
+                    28.924335785215973
+                ],
+                [
+                    -95.24365425109863,
+                    28.89969215375586
+                ],
+                [
+                    -95.23927688598633,
+                    28.90405029511776
+                ],
+                [
+                    -95.23979187011719,
+                    28.929143616007288
+                ],
+                [
+                    -95.26897430419922,
+                    28.951677350293465
+                ],
+                [
+                    -95.35978317260742,
+                    29.022626563968657
+                ],
+                [
+                    -95.4081916809082,
+                    29.061796677850424
+                ],
+                [
+                    -95.42673110961913,
+                    29.048441489877778
+                ],
+                [
+                    -95.44741630554199,
+                    29.064872627755797
+                ],
+                [
+                    -95.46260833740233,
+                    29.06442249447776
+                ],
+                [
+                    -95.46998977661133,
+                    29.059245820517656
+                ]
+            ]
+        ]
+    },
+    "links": [
+        {
+            "rel": "collection",
+            "href": "../../../collection.json"
+        },
+        {
+            "rel": "root",
+            "href": "../../../collection.json",
+            "type": "application/json"
+        },
+        {
+            "rel": "parent",
+            "href": "../catalog.json",
+            "type": "application/json"
+        }
+    ],
+    "assets": {
+        "thumbnail": {
+            "href": "https://storage.googleapis.com/pdd-stac/disasters/hurricane-harvey/0831/SkySat_Freeport_s03_20170831T162740Z.png",
+            "type": "image/png",
+            "title": "Thumbnail",
+            "roles": [
+                "thumbnail"
+            ]
+        },
+        "visual": {
+            "href": "https://storage.googleapis.com/pdd-stac/disasters/hurricane-harvey/0831/SkySat_Freeport_s03_20170831T162740Z.tif",
+            "type": "image/vnd.stac.geotiff; cloud-optimized=true",
+            "title": "SkySatScene Visual GeoTIFF",
+            "pl:type": "https://api.planet.com/data/v1/asset-types/ortho_visual",
+            "roles": [
+                "data"
+            ]
+        }
+    },
+    "bbox": [
+        -95.46998977661133,
+        28.872261720487128,
+        -95.23927688598633,
+        29.064872627755797
+    ],
+    "stac_extensions": [
+        "https://stac-extensions.github.io/eo/v1.0.0/schema.json",
+        "https://stac-extensions.github.io/view/v1.0.0/schema.json"
+    ],
+    "collection": "planet-disaster-data"
+}

--- a/tests/data/planet-example-v1.0.0-beta.2/hurricane-harvey/hurricane-harvey-0831/20170831_172754_101c/20170831_172754_101c.json
+++ b/tests/data/planet-example-v1.0.0-beta.2/hurricane-harvey/hurricane-harvey-0831/20170831_172754_101c/20170831_172754_101c.json
@@ -1,0 +1,149 @@
+{
+    "type": "Feature",
+    "stac_version": "1.0.0-rc.3",
+    "id": "20170831_172754_101c",
+    "properties": {
+        "datetime": "2017-08-31T17:27:54.960530Z",
+        "instruments": [
+            "PS2"
+        ],
+        "platform": "101c",
+        "constellation": "planetscope",
+        "created": "2017-10-27T12:14:07Z",
+        "updated": "2017-12-07T07:37:28Z",
+        "gsd": 2.6,
+        "eo:cloud_cover": 2,
+        "view:sun_azimuth": 145.4,
+        "view:sun_elevation": 65.1,
+        "view:off_nadir": 0.2,
+        "proj:epsg": 32615,
+        "pl:anomalous_pixels": 0.01,
+        "pl:columns": 8307,
+        "pl:ground_control": true,
+        "pl:item_type": "PSScene4Band",
+        "pl:origin_x": 205503,
+        "pl:origin_y": 3280320,
+        "pl:pixel_resolution": 3,
+        "pl:quality_category": "test",
+        "pl:rows": 3918,
+        "pl:strip_id": "724553",
+        "pl:usable_data": 0
+    },
+    "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+            [
+                [
+                    -96.03352746458962,
+                    29.549057939888584
+                ],
+                [
+                    -96.03810006842333,
+                    29.569454227086553
+                ],
+                [
+                    -96.03730797076582,
+                    29.569591543553933
+                ],
+                [
+                    -96.04001623809913,
+                    29.581290775117473
+                ],
+                [
+                    -95.79781720037577,
+                    29.62330817060518
+                ],
+                [
+                    -95.78672161779234,
+                    29.575096137087073
+                ],
+                [
+                    -95.7821382652893,
+                    29.55447424651818
+                ],
+                [
+                    -96.0250376017418,
+                    29.512344359576105
+                ],
+                [
+                    -96.03352746458962,
+                    29.549057939888584
+                ]
+            ]
+        ]
+    },
+    "links": [
+        {
+            "rel": "collection",
+            "href": "../../../collection.json"
+        },
+        {
+            "rel": "root",
+            "href": "../../../collection.json",
+            "type": "application/json"
+        },
+        {
+            "rel": "parent",
+            "href": "../catalog.json",
+            "type": "application/json"
+        }
+    ],
+    "assets": {
+        "thumbnail": {
+            "href": "https://storage.googleapis.com/pdd-stac/disasters/hurricane-harvey/0831/20170831_172754_101c_thumb_large.png",
+            "type": "image/png",
+            "title": "Thumbnail",
+            "roles": [
+                "thumbnail"
+            ]
+        },
+        "analytic": {
+            "href": "https://storage.googleapis.com/pdd-stac/disasters/hurricane-harvey/0831/20170831_172754_101c_3B_AnalyticMS.tif",
+            "type": "image/vnd.stac.geotiff; cloud-optimized=true",
+            "title": "PSScene4Band Analytic GeoTIFF",
+            "pl:type": "https://api.planet.com/data/v1/asset-types/analytic",
+            "roles": [
+                "data"
+            ]
+        },
+        "analytic_xml": {
+            "href": "https://storage.googleapis.com/pdd-stac/disasters/hurricane-harvey/0831/20170831_172754_101c_3B_AnalyticMS_metadata.xml",
+            "type": "text/xml",
+            "title": "PSScene4Band XML Metadata",
+            "pl:type": "https://api.planet.com/data/v1/asset-types/analytic_xml",
+            "roles": [
+                "metadata"
+            ]
+        },
+        "udm": {
+            "href": "https://storage.googleapis.com/pdd-stac/disasters/hurricane-harvey/0831/20170831_172754_101c_3B_AnalyticMS_DN_udm.tif",
+            "type": "image/vnd.stac.geotiff; cloud-optimized=true",
+            "title": "PSScene4Band Unusable Data Mask",
+            "pl:type": "https://api.planet.com/data/v1/asset-types/udm",
+            "roles": [
+                "udm"
+            ]
+        },
+        "visual": {
+            "href": "https://storage.googleapis.com/pdd-stac/disasters/hurricane-harvey/0831/20170831_172754_101c_3b_Visual.tif",
+            "type": "image/vnd.stac.geotiff; cloud-optimized=true",
+            "title": "PSScene3Band Visual GeoTIFF",
+            "pl:type": "https://api.planet.com/data/v1/asset-types/visual",
+            "roles": [
+                "visual"
+            ]
+        }
+    },
+    "bbox": [
+        -96.04001623809913,
+        29.512344359576105,
+        -95.7821382652893,
+        29.62330817060518
+    ],
+    "stac_extensions": [
+        "https://stac-extensions.github.io/eo/v1.0.0/schema.json",
+        "https://stac-extensions.github.io/view/v1.0.0/schema.json",
+        "https://stac-extensions.github.io/projection/v1.0.0/schema.json"
+    ],
+    "collection": "planet-disaster-data"
+}

--- a/tests/data/planet-example-v1.0.0-beta.2/hurricane-harvey/hurricane-harvey-0831/20170831_195425_SS02/20170831_195425_SS02.json
+++ b/tests/data/planet-example-v1.0.0-beta.2/hurricane-harvey/hurricane-harvey-0831/20170831_195425_SS02/20170831_195425_SS02.json
@@ -1,0 +1,128 @@
+{
+    "type": "Feature",
+    "stac_version": "1.0.0-rc.3",
+    "id": "20170831_195425_SS02",
+    "properties": {
+        "datetime": "2017-08-31T19:54:26.532800Z",
+        "updated": "2017-11-01T21:14:45Z",
+        "created": "2017-09-01T19:15:30Z",
+        "platform": "SS02",
+        "gsd": 1.1,
+        "eo:cloud_cover": 0,
+        "view:azimuth": 202.8,
+        "view:sun_azimuth": 231.9,
+        "view:sun_elevation": 58.4,
+        "view:off_nadir": 27.3,
+        "pl:ground_control": true,
+        "pl:item_type": "SkySatScene",
+        "pl:provider": "skysat",
+        "pl:quality_category": "test",
+        "pl:satellite_azimuth": 329.8,
+        "pl:strip_id": "s02_20170831T195425Z"
+    },
+    "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+            [
+                [
+                    -94.11540985107422,
+                    29.998057058071883
+                ],
+                [
+                    -94.11609649658203,
+                    29.96564257441305
+                ],
+                [
+                    -93.82942199707031,
+                    29.916554657596713
+                ],
+                [
+                    -93.8283920288086,
+                    29.94660528850718
+                ],
+                [
+                    -93.79920959472656,
+                    29.942737894394064
+                ],
+                [
+                    -93.79989624023438,
+                    29.977836419653794
+                ],
+                [
+                    -93.82736206054688,
+                    29.981405066834853
+                ],
+                [
+                    -93.82530212402342,
+                    30.011436098225726
+                ],
+                [
+                    -94.11540985107422,
+                    30.052156732418428
+                ],
+                [
+                    -94.11678314208984,
+                    30.02094898463764
+                ],
+                [
+                    -94.10202026367188,
+                    30.017679032856247
+                ],
+                [
+                    -94.10408020019531,
+                    29.99627304975274
+                ],
+                [
+                    -94.11540985107422,
+                    29.998057058071883
+                ]
+            ]
+        ]
+    },
+    "links": [
+        {
+            "rel": "collection",
+            "href": "../../../collection.json"
+        },
+        {
+            "rel": "root",
+            "href": "../../../collection.json",
+            "type": "application/json"
+        },
+        {
+            "rel": "parent",
+            "href": "../catalog.json",
+            "type": "application/json"
+        }
+    ],
+    "assets": {
+        "thumbnail": {
+            "href": "https://storage.googleapis.com/pdd-stac/disasters/hurricane-harvey/0831/SkySat_PortArthur_s02_20170831T195425Z.png",
+            "type": "image/png",
+            "title": "Thumbnail",
+            "roles": [
+                "thumbnail"
+            ]
+        },
+        "visual": {
+            "href": "https://storage.googleapis.com/pdd-stac/disasters/hurricane-harvey/0831/SkySat_PortArthur_s02_20170831T195425Z.tif",
+            "type": "image/vnd.stac.geotiff; cloud-optimized=true",
+            "title": "SkySatScene Visual GeoTIFF",
+            "pl:type": "https://api.planet.com/data/v1/asset-types/ortho_visual",
+            "roles": [
+                "data"
+            ]
+        }
+    },
+    "bbox": [
+        -94.11678314208984,
+        29.916554657596713,
+        -93.79920959472656,
+        30.052156732418428
+    ],
+    "stac_extensions": [
+        "https://stac-extensions.github.io/eo/v1.0.0/schema.json",
+        "https://stac-extensions.github.io/view/v1.0.0/schema.json"
+    ],
+    "collection": "planet-disaster-data"
+}

--- a/tests/data/planet-example-v1.0.0-beta.2/hurricane-harvey/hurricane-harvey-0831/2017831_195552_SS02/2017831_195552_SS02.json
+++ b/tests/data/planet-example-v1.0.0-beta.2/hurricane-harvey/hurricane-harvey-0831/2017831_195552_SS02/2017831_195552_SS02.json
@@ -1,0 +1,147 @@
+{
+    "type": "Feature",
+    "stac_version": "1.0.0-rc.3",
+    "id": "2017831_195552_SS02",
+    "properties": {
+        "datetime": "2017-08-31T19:55:53.513448Z",
+        "constellation": "skysat",
+        "platform": "SS02",
+        "created": "2017-09-01T19:31:37Z",
+        "updated": "2017-11-01T20:32:39Z",
+        "gsd": 1.1,
+        "eo:cloud_cover": 24,
+        "view:azimuth": 202.8,
+        "view:sun_azimuth": 230.3,
+        "view:sun_elevation": 59.4,
+        "view:off_nadir": 25,
+        "pl:ground_control": true,
+        "pl:item_type": "SkySatScene",
+        "pl:quality_category": "test",
+        "pl:strip_id": "s02_20170831T195552Z"
+    },
+    "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+            [
+                [
+                    -95.82155227661133,
+                    29.834836581964858
+                ],
+                [
+                    -95.8256721496582,
+                    29.798198028657897
+                ],
+                [
+                    -95.77760696411131,
+                    29.797900099223124
+                ],
+                [
+                    -95.78086853027344,
+                    29.771082817849976
+                ],
+                [
+                    -95.82841873168945,
+                    29.77078480770624
+                ],
+                [
+                    -95.83253860473631,
+                    29.73442091918209
+                ],
+                [
+                    -95.52492141723633,
+                    29.7397869125961
+                ],
+                [
+                    -95.52217483520508,
+                    29.76795366711911
+                ],
+                [
+                    -95.4770278930664,
+                    29.76810267651335
+                ],
+                [
+                    -95.47307968139648,
+                    29.801177274210758
+                ],
+                [
+                    -95.51874160766602,
+                    29.801624153391575
+                ],
+                [
+                    -95.5154800415039,
+                    29.830071351055686
+                ],
+                [
+                    -95.61573028564453,
+                    29.83215616754356
+                ],
+                [
+                    -95.62946319580078,
+                    29.832751821407317
+                ],
+                [
+                    -95.7513427734375,
+                    29.834092029616816
+                ],
+                [
+                    -95.82155227661133,
+                    29.834836581964858
+                ]
+            ]
+        ]
+    },
+    "links": [
+        {
+            "rel": "collection",
+            "href": "../../../collection.json"
+        },
+        {
+            "rel": "root",
+            "href": "../../../collection.json",
+            "type": "application/json"
+        },
+        {
+            "rel": "parent",
+            "href": "../catalog.json",
+            "type": "application/json"
+        }
+    ],
+    "assets": {
+        "thumbnail": {
+            "href": "https://storage.googleapis.com/pdd-stac/disasters/hurricane-harvey/0831/SkySat_20170831T195552Z_RGB.png",
+            "type": "image/png",
+            "title": "Thumbnail",
+            "roles": [
+                "thumbnail"
+            ]
+        },
+        "visual": {
+            "href": "https://storage.googleapis.com/pdd-stac/disasters/hurricane-harvey/0831/SkySat_20170831T195552Z_RGB.tif",
+            "type": "image/vnd.stac.geotiff; cloud-optimized=true",
+            "title": "SkySatScene Visual GeoTIFF",
+            "pl:type": "https://api.planet.com/data/v1/asset-types/ortho_visual",
+            "roles": [
+                "data"
+            ]
+        },
+        "full-jpg": {
+            "href": "https://storage.googleapis.com/pdd-stac/disasters/hurricane-harvey/0831/SkySat_20170831T195552Z_RGB_Corrected.jpg",
+            "type": "image/jpeg",
+            "title": "SkySatScene Visual JPG",
+            "roles": [
+                "overview"
+            ]
+        }
+    },
+    "bbox": [
+        -95.83253860473631,
+        29.73442091918209,
+        -95.47307968139648,
+        29.834836581964858
+    ],
+    "stac_extensions": [
+        "https://stac-extensions.github.io/eo/v1.0.0/schema.json",
+        "https://stac-extensions.github.io/view/v1.0.0/schema.json"
+    ],
+    "collection": "planet-disaster-data"
+}

--- a/tests/data/planet-example-v1.0.0-beta.2/hurricane-harvey/hurricane-harvey-0831/Houston-East-20170831-103f-100d-0f4f-RGB/Houston-East-20170831-103f-100d-0f4f-RGB.json
+++ b/tests/data/planet-example-v1.0.0-beta.2/hurricane-harvey/hurricane-harvey-0831/Houston-East-20170831-103f-100d-0f4f-RGB/Houston-East-20170831-103f-100d-0f4f-RGB.json
@@ -1,0 +1,92 @@
+{
+    "type": "Feature",
+    "stac_version": "1.0.0-rc.3",
+    "id": "Houston-East-20170831-103f-100d-0f4f-RGB",
+    "properties": {
+        "datetime": "2017-08-31T17:24:57.555491Z",
+        "constellation": "planetscope",
+        "instruments": [
+            "PS2"
+        ],
+        "gsd": 3.7,
+        "eo:cloud_cover": 2,
+        "view:sun_azimuth": 145.5,
+        "view:sun_elevation": 64.9,
+        "view:off_nadir": 0.2,
+        "proj:epsg": 32615,
+        "pl:ground_control": true
+    },
+    "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+            [
+                [
+                    -95.73737276800716,
+                    30.14525788823348
+                ],
+                [
+                    -95.06532619920118,
+                    30.157560439570304
+                ],
+                [
+                    -95.05332428370095,
+                    29.57334931237589
+                ],
+                [
+                    -95.7214758280382,
+                    29.561332400220497
+                ],
+                [
+                    -95.73737276800716,
+                    30.14525788823348
+                ]
+            ]
+        ]
+    },
+    "links": [
+        {
+            "rel": "collection",
+            "href": "../../../collection.json"
+        },
+        {
+            "rel": "root",
+            "href": "../../../collection.json",
+            "type": "application/json"
+        },
+        {
+            "rel": "parent",
+            "href": "../catalog.json",
+            "type": "application/json"
+        }
+    ],
+    "assets": {
+        "thumbnail": {
+            "href": "https://storage.googleapis.com/pdd-stac/disasters/hurricane-harvey/0831/Houston-East-20170831-103f-100d-0f4f-3-band.png",
+            "type": "image/png",
+            "title": "Thumbnail",
+            "roles": [
+                "thumbnail"
+            ]
+        },
+        "mosaic": {
+            "href": "https://storage.googleapis.com/pdd-stac/disasters/hurricane-harvey/0831/Houston-East-20170831-103f-100d-0f4f-3-band.tif",
+            "type": "image/vnd.stac.geotiff; cloud-optimized=true",
+            "title": "3 Band RGB Mosaic",
+            "roles": [
+                "data"
+            ]
+        }
+    },
+    "bbox": [
+        -95.73737276800716,
+        29.561332400220497,
+        -95.05332428370095,
+        30.157560439570304
+    ],
+    "stac_extensions": [
+        "https://stac-extensions.github.io/eo/v1.0.0/schema.json",
+        "https://stac-extensions.github.io/view/v1.0.0/schema.json",
+        "https://stac-extensions.github.io/projection/v1.0.0/schema.json"
+    ],
+    "collection": "planet-disaster-data"
+}

--- a/tests/data/planet-example-v1.0.0-beta.2/hurricane-harvey/hurricane-harvey-0831/catalog.json
+++ b/tests/data/planet-example-v1.0.0-beta.2/hurricane-harvey/hurricane-harvey-0831/catalog.json
@@ -1,0 +1,43 @@
+{
+    "id": "hurricane-harvey-0831",
+    "stac_version": "1.0.0-beta.2",
+    "description": "Planet Scenes and Composites for Hurricane Harvey on Aug 31, 2017",
+    "links": [
+        {
+            "rel": "root",
+            "href": "../../collection.json",
+            "type": "application/json"
+        },
+        {
+            "rel": "parent",
+            "href": "../catalog.json",
+            "type": "application/json"
+        },
+        {
+            "rel": "item",
+            "href": "./20170831_172754_101c/20170831_172754_101c.json",
+            "title": "20170831_172754_101c"
+        },
+        {
+            "rel": "item",
+            "href": "./2017831_195552_SS02/2017831_195552_SS02.json",
+            "title": "20170831_195552_SS02"
+        },
+        {
+            "rel": "item",
+            "href": "./20170831_195425_SS02/20170831_195425_SS02.json",
+            "title": "20170831_195425_SS02"
+        },
+        {
+            "rel": "item",
+            "href": "./20170831_162740_ssc1d1/20170831_162740_ssc1d1.json",
+            "title": "20170831_162740_ssc1d1"
+        },
+        {
+            "rel": "item",
+            "href": "./Houston-East-20170831-103f-100d-0f4f-RGB/Houston-East-20170831-103f-100d-0f4f-RGB.json",
+            "title": "Houston-East-20170831-103f-100d-0f4f-RGB"
+        }
+    ],
+    "title": "Hurricane Harvey 08-31-2017"
+}

--- a/tests/stac_data.py
+++ b/tests/stac_data.py
@@ -1,0 +1,15 @@
+import os
+
+import pystac
+
+TEST_CATALOG = pystac.Catalog.from_file(
+    os.path.join(
+        "tests",
+        "data",
+        "planet-example-v1.0.0-beta.2",
+        "hurricane-harvey",
+        "catalog.json",
+    )
+)
+TEST_ITEM_COLLECTION = pystac.ItemCollection(TEST_CATALOG.get_all_items())
+TEST_ITEM = TEST_ITEM_COLLECTION[0]

--- a/tests/test_explore.py
+++ b/tests/test_explore.py
@@ -1,0 +1,219 @@
+import copy
+
+import pystac
+import pytest
+
+import stacmap
+
+from .stac_data import TEST_ITEM, TEST_ITEM_COLLECTION
+
+
+def _fetch_map_string(m):
+    """https://github.com/geopandas/geopandas/blob/main/geopandas/tests/test_explore.py"""
+    out = m._parent.render()
+    return out
+
+
+def _get_first_child(m, name):
+    """Get the first child element from a map that starts with a name substring"""
+    for child in m._children:
+        if child.startswith(name):
+            return m._children[child]
+    return None
+
+
+def test_continuous_prop():
+    m = stacmap.explore(
+        TEST_ITEM_COLLECTION, prop="eo:cloud_cover", vmin=4, vmax=20, name="TEST DATA"
+    )
+    m.render()
+
+    layer_control = _get_first_child(m, "layer_control")
+    assert "TEST DATA - Footprints" in layer_control.overlays
+
+    legend = _get_first_child(m, "color_map")
+    assert legend is not None
+    assert legend.vmin == 4
+    assert legend.vmax == 20
+    assert legend.caption == "TEST DATA: eo:cloud_cover"
+
+
+def test_categorical_prop():
+    m = stacmap.explore(
+        TEST_ITEM_COLLECTION, prop="eo:cloud_cover", force_categorical=True
+    )
+    m.render()
+
+    layer_control = _get_first_child(m, "layer_control")
+    assert "planet-disaster-data - Footprints" in layer_control.overlays
+
+    html = _fetch_map_string(m)
+    assert (
+        "<div class='legend-title'>planet-disaster-data: eo:cloud_cover</div>" in html
+    )
+    assert "<li><span style='background:#e41a1c'></span>0</li>" in html
+
+
+def test_no_legend():
+    m = stacmap.explore(TEST_ITEM_COLLECTION, prop="eo:cloud_cover", legend=False)
+    m.render()
+
+    html = _fetch_map_string(m)
+    assert (
+        "<div class='legend-title'>planet-disaster-data: eo:cloud_cover</div>"
+        not in html
+    )
+
+
+def test_existing_map():
+    m = stacmap.explore(TEST_ITEM_COLLECTION, name="DATA 1")
+    m = stacmap.explore(TEST_ITEM_COLLECTION, name="DATA 2", m=m)
+    m.render()
+
+    layer_control = _get_first_child(m, "layer_control")
+    assert "DATA 1 - Footprints" in layer_control.overlays
+    assert "DATA 2 - Footprints" in layer_control.overlays
+
+
+def test_map_kwds():
+    m = stacmap.explore(
+        TEST_ITEM_COLLECTION, width=300, height=150, map_kwds={"zoomStart": 14}
+    )
+    assert m.width[0] == 300.0
+    assert m.height[0] == 150.0
+    assert m.options["zoomStart"] == 14
+
+
+def test_bbox():
+    bbox = (0, 0, 30, 30)
+    m = stacmap.explore(TEST_ITEM_COLLECTION, name="LAYER", bbox=bbox)
+    m.render()
+
+    layer_control = _get_first_child(m, "layer_control")
+    assert "LAYER - Bounds" in layer_control.overlays
+
+
+def test_intersects():
+    intersects = dict(type="Point", coordinates=[125.6, 10.1])
+    m = stacmap.explore(TEST_ITEM_COLLECTION, name="LAYER", intersects=intersects)
+    m.render()
+
+    layer_control = _get_first_child(m, "layer_control")
+    assert "LAYER - Bounds" in layer_control.overlays
+
+
+def test_bbox_and_intersects():
+    bbox = (0, 0, 30, 30)
+    intersects = dict(type="Point", coordinates=[125.6, 10.1])
+
+    with pytest.raises(ValueError, match="Cannot specify both"):
+        stacmap.explore(TEST_ITEM_COLLECTION, bbox=bbox, intersects=intersects)
+
+
+def test_highlight():
+    m = stacmap.explore(TEST_ITEM_COLLECTION, highlight=False)
+    layer = _get_first_child(m, "geo_json")
+    assert layer.highlight_function(None) == {}
+
+    highlight_kwds = {"fillOpacity": 0.9, "stroke": False}
+    m = stacmap.explore(TEST_ITEM_COLLECTION, highlight_kwds=highlight_kwds)
+    layer = _get_first_child(m, "geo_json")
+    assert layer.highlight_function(None) == highlight_kwds
+
+
+def test_style():
+    style_kwds = {"color": "red", "fillOpacity": 0.9, "stroke": False}
+    m = stacmap.explore(TEST_ITEM_COLLECTION, style_kwds=style_kwds)
+    layer = _get_first_child(m, "geo_json")
+    assert layer.style_function(None) == style_kwds
+
+    # Prop-derived color should overwrite `color` and `fillColor` in style_kwds
+    style_kwds = {"color": "red", "fillOpacity": 0.9, "stroke": False}
+    m = stacmap.explore(
+        TEST_ITEM_COLLECTION, prop="eo:cloud_cover", style_kwds=style_kwds
+    )
+    layer = _get_first_child(m, "geo_json")
+    item = copy.deepcopy(TEST_ITEM.to_dict())
+    item["properties"]["__stacmap_color"] = "cyan"
+
+    assert layer.style_function(item)["color"] == "cyan"
+    assert layer.style_function(item)["fillColor"] == "cyan"
+
+
+def test_tooltip_and_popup():
+    m = stacmap.explore(TEST_ITEM_COLLECTION)
+    layer = _get_first_child(m, "geo_json")
+    tooltip = _get_first_child(layer, "geo_json_tooltip")
+    popup = _get_first_child(layer, "geo_json_popup")
+    assert tooltip is not None
+    assert popup is None
+
+    m = stacmap.explore(TEST_ITEM_COLLECTION, tooltip=False, popup=True)
+    layer = _get_first_child(m, "geo_json")
+    tooltip = _get_first_child(layer, "geo_json_tooltip")
+    popup = _get_first_child(layer, "geo_json_popup")
+    assert tooltip is None
+    assert popup is not None
+
+    m = stacmap.explore(TEST_ITEM_COLLECTION, tooltip_kwds={"sticky": True})
+    layer = _get_first_child(m, "geo_json")
+    tooltip = _get_first_child(layer, "geo_json_tooltip")
+    assert tooltip.tooltip_options["sticky"] == True
+
+
+def test_fields():
+    fields = ["eo:cloud_cover", "view:off_nadir"]
+    m = stacmap.explore(TEST_ITEM_COLLECTION, fields=fields)
+    layer = _get_first_child(m, "geo_json")
+    tooltip = _get_first_child(layer, "geo_json_tooltip")
+
+    assert tooltip.fields == fields
+
+
+def test_tiles():
+    m = stacmap.explore(TEST_ITEM_COLLECTION, tiles="cartodbpositron")
+    tiles = _get_first_child(m, "cartodbpositron")
+    assert tiles is not None
+
+    with pytest.raises(ValueError, match="must have an attribution"):
+        stacmap.explore(TEST_ITEM_COLLECTION, tiles="notrealtiles")
+    stacmap.explore(TEST_ITEM_COLLECTION, tiles="notrealtiles", attr="attr text")
+
+
+def test_empty_stac():
+    with pytest.raises(ValueError, match="No STAC items were found"):
+        stacmap.explore(pystac.ItemCollection(items=[]))
+
+
+def test_thumbnails():
+    m = stacmap.explore(TEST_ITEM, thumbnails=True, name="LAYER")
+    m.render()
+    layer_control = _get_first_child(m, "layer_control")
+    assert "LAYER - Thumbnails" in layer_control.overlays
+
+    test_item = copy.deepcopy(TEST_ITEM.to_dict())
+    del test_item["assets"]["thumbnail"]
+    with pytest.raises(ValueError, match="do not have thumbnail links"):
+        stacmap.explore(test_item, thumbnails=True)
+
+
+def test_add_id():
+    # The `id` property should be automatically populated from the STAC ID
+    test_item = copy.deepcopy(TEST_ITEM.to_dict())
+    m = stacmap.explore(test_item, name="LAYER")
+    layer = _get_first_child(m, "geo_json")
+    assert layer.data["features"][0]["properties"]["id"] == "20170831_172754_101c"
+
+    # Using `add_id=False` should prevent an ID property from being added
+    test_item = copy.deepcopy(TEST_ITEM.to_dict())
+    m = stacmap.explore(test_item, name="LAYER", add_id=False)
+    layer = _get_first_child(m, "geo_json")
+    assert "id" not in layer.data["features"][0]["properties"]
+
+    # If an item already has an ID property, it shouldn't be overwritten
+    test_item = copy.deepcopy(TEST_ITEM.to_dict())
+    test_item["properties"]["id"] = "MY CUSTOM ID"
+
+    m = stacmap.explore(test_item, name="LAYER")
+    layer = _get_first_child(m, "geo_json")
+    assert layer.data["features"][0]["properties"]["id"] == "MY CUSTOM ID"

--- a/tests/test_geojson.py
+++ b/tests/test_geojson.py
@@ -1,0 +1,20 @@
+import pytest
+
+from stacmap.geojson import STACFeatureCollection
+from stacmap.stac import get_items
+
+from .stac_data import TEST_ITEM_COLLECTION
+
+
+def test_len():
+    items = get_items(TEST_ITEM_COLLECTION)
+    fc = STACFeatureCollection(items)
+    assert len(fc) == 5
+
+
+def test_get_missing_value():
+    items = get_items(TEST_ITEM_COLLECTION)
+    fc = STACFeatureCollection(items)
+
+    with pytest.raises(ValueError):
+        fc.get_values("not_a_real_prop")

--- a/tests/test_stac.py
+++ b/tests/test_stac.py
@@ -1,20 +1,8 @@
-import datetime
+import pytest
 
-import pystac
+from stacmap.stac import get_dict_from_item, get_items
 
-from stacmap.stac import get_items
-
-TEST_ITEM = pystac.Item(
-    id="item1",
-    geometry={"type": "Point", "coordinates": [0, 0]},
-    bbox=[0, 0, 1, 1],
-    datetime=datetime.datetime.now(),
-    properties={"prop1": "value1"},
-)
-
-TEST_COLLECTION = pystac.ItemCollection([TEST_ITEM, TEST_ITEM])
-TEST_CATALOG = pystac.Catalog(id="catalog1", description="Test catalog")
-TEST_CATALOG.add_item(TEST_ITEM)
+from .stac_data import TEST_CATALOG, TEST_ITEM, TEST_ITEM_COLLECTION
 
 
 def test_get_items_from_item():
@@ -42,7 +30,7 @@ def test_get_items_from_list_of_item_dicts():
 
 
 def test_get_items_from_collection():
-    item_dict = get_items(TEST_COLLECTION)
+    item_dict = get_items(TEST_ITEM_COLLECTION)
     assert isinstance(item_dict, list)
     assert isinstance(item_dict[0], dict)
 
@@ -51,3 +39,13 @@ def test_get_items_from_catalog():
     item_dict = get_items(TEST_CATALOG)
     assert isinstance(item_dict, list)
     assert isinstance(item_dict[0], dict)
+
+
+def test_get_items_from_non_stac():
+    with pytest.raises(ValueError):
+        get_items(4)
+
+
+def test_get_dict_from_item_from_non_item():
+    with pytest.raises(ValueError):
+        get_dict_from_item(4)


### PR DESCRIPTION
- Add full test coverage
- Add test STAC data
- Close #6 by raising a `ValueError` if no thumbnails links are found
- Refactor legends in `explore.py` 